### PR TITLE
Allow control over which character is used to enclose each cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,39 @@ Following a request to add [this feature](https://github.com/abdennour/react-csv
 import { CSVLink } from "react-csv";
 
 <CSVLink data={array} separator={";"}>
+<<<<<<< HEAD
   Download me
 </CSVLink>;
 /*
   This will generate CSV with ";" as delimiter (separator)
+=======
+    Download me
+</CSVLink>
+
+/*
+    "foo";"bar"
+    "a";"b"
+>>>>>>> Update README
  */
+```
+
+### - **enclosingCharacter** Props:
+
+Following a request to add [this feature](https://github.com/abdennour/react-csv/issues/68), `react-csv` supports an `enclosingCharacter` prop which defaults to `"`.
+
+
+```js
+import {CSVLink} from 'react-csv';
+
+<CSVLink data={array} enclosingCharacter={`'`}>
+    Download me
+</CSVLink>
+
+/*
+    'foo','bar'
+    'a','b'
+ */
+
 ```
 
 ## 1. CSVLink Component:

--- a/README.md
+++ b/README.md
@@ -160,19 +160,12 @@ Following a request to add [this feature](https://github.com/abdennour/react-csv
 import { CSVLink } from "react-csv";
 
 <CSVLink data={array} separator={";"}>
-<<<<<<< HEAD
-  Download me
-</CSVLink>;
-/*
-  This will generate CSV with ";" as delimiter (separator)
-=======
     Download me
 </CSVLink>
 
 /*
     "foo";"bar"
     "a";"b"
->>>>>>> Update README
  */
 ```
 

--- a/sample-site/src/app.jsx
+++ b/sample-site/src/app.jsx
@@ -44,7 +44,10 @@ class App extends React.Component {
                     headers={csvHeaders}
                     data={csvData}
                     filename={this.getFileName()}
-                    className="btn">Export to CSV ⬇</CSVLink>
+                    className="btn"
+                  >
+                    Export to CSV ⬇
+                  </CSVLink>
               </div>
           </div>
 

--- a/src/components/Download.js
+++ b/src/components/Download.js
@@ -30,9 +30,9 @@ class CSVDownload extends React.Component {
   }
 
   componentDidMount(){
-    const {data, headers, separator, uFEFF, target, specs, replace} = this.props;
+    const {data, headers, separator, enclosingCharacter, uFEFF, target, specs, replace} = this.props;
     this.state.page = window.open(
-        this.buildURI(data, uFEFF, headers, separator), target, specs, replace
+        this.buildURI(data, uFEFF, headers, separator, enclosingCharacter), target, specs, replace
     );
   }
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -20,8 +20,8 @@ class CSVLink extends React.Component {
   }
 
   componentDidMount() {
-    const { data, headers, separator, uFEFF } = this.props;
-    this.setState({ href: this.buildURI(data, uFEFF, headers, separator) });
+    const {data, headers, separator, uFEFF, enclosingCharacter} = this.props;
+    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter) });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -36,13 +36,13 @@ class CSVLink extends React.Component {
   /**
    * In IE11 this method will trigger the file download
    */
-  handleLegacy(event, data, headers, separator, filename) {
+  handleLegacy(evt, data, headers, separator, filename, enclosingCharacter) {
     // If this browser is IE 11, it does not support the `download` attribute
     if (window.navigator.msSaveOrOpenBlob) {
       // Stop the click propagation
       event.preventDefault();
 
-      let blob = new Blob([toCSV(data, headers, separator)]);
+      let blob = new Blob([toCSV(data, headers, separator, enclosingCharacter)]);
       window.navigator.msSaveBlob(blob, filename);
 
       return false;
@@ -91,17 +91,18 @@ class CSVLink extends React.Component {
       children,
       onClick,
       asyncOnClick,
+      enclosingCharacter,
       ...rest
     } = this.props;
-    const { href } = this.state;
+
     return (
       <a
         download={filename}
         {...rest}
         ref={link => (this.link = link)}
         target="_self"
-        href={href}
-        onClick={this.handleClick(data, headers, separator, filename)}
+        href={this.state.href}
+        onClick={this.handleClick(data, headers, separator, filename, enclosingCharacter)}
       >
         {children}
       </a>

--- a/src/core.js
+++ b/src/core.js
@@ -49,34 +49,39 @@ export const getHeaderValue = (property, obj) => {
 
 export const elementOrEmpty = (element) => element || element === 0 ? element : '';
 
-export const joiner = ((data,separator = ',') => {
-  const filteredData = data.filter(e=>e);
-  return filteredData.map((row, index) => row.map((element) => "\"" + elementOrEmpty(element) + "\"").join(separator)
-  ).join(`\n`);
-}
+export const joiner = ((data, separator = ',', enclosingCharacter = '"') => {
+  return data
+    .filter(e => e)
+    .map(
+      row => row
+        .map((element) => elementOrEmpty(element))
+        .map(column => `${enclosingCharacter}${column}${enclosingCharacter}`)
+        .join(separator)
+    )
+    .join(`\n`);
+});
+
+export const arrays2csv = ((data, headers, separator, enclosingCharacter) =>
+ joiner(headers ? [headers, ...data] : data, separator, enclosingCharacter)
 );
 
-export const arrays2csv = ((data, headers, separator) =>
- joiner(headers ? [headers, ...data] : data, separator)
+export const jsons2csv = ((data, headers, separator, enclosingCharacter) =>
+ joiner(jsons2arrays(data, headers), separator, enclosingCharacter)
 );
 
-export const jsons2csv = ((data, headers, separator) =>
- joiner(jsons2arrays(data, headers), separator)
-);
-
-export const string2csv = ((data, headers, separator) =>
+export const string2csv = ((data, headers, separator, enclosingCharacter) =>
   (headers) ? `${headers.join(separator)}\n${data}`: data
 );
 
-export const toCSV = (data, headers, separator) => {
- if (isJsons(data)) return jsons2csv(data, headers, separator);
- if (isArrays(data)) return arrays2csv(data, headers, separator);
+export const toCSV = (data, headers, separator, enclosingCharacter) => {
+ if (isJsons(data)) return jsons2csv(data, headers, separator, enclosingCharacter);
+ if (isArrays(data)) return arrays2csv(data, headers, separator, enclosingCharacter);
  if (typeof data ==='string') return string2csv(data, headers, separator);
  throw new TypeError(`Data should be a "String", "Array of arrays" OR "Array of objects" `);
 };
 
-export const buildURI = ((data, uFEFF, headers, separator) => {
-  const csv = toCSV(data, headers, separator);
+export const buildURI = ((data, uFEFF, headers, separator, enclosingCharacter) => {
+  const csv = toCSV(data, headers, separator, enclosingCharacter);
   const type = isSafari() ? 'application/csv' : 'text/csv';
   const blob = new Blob([uFEFF ? '\uFEFF' : '', csv], {type});
   const dataURI = `data:${type};charset=utf-8,${uFEFF ? '\uFEFF' : ''}${csv}`;


### PR DESCRIPTION
## Changes
- Added `enclosingCharacter` prop to provide control over how each cell is enclosed (defaults to double quotes, ")

The prop name is a bit verbose, and I'm happy to change it to something shorter if anybody has any suggestions.

Fixes #68