### PR TITLE
Add \uFEFF to Link handleLegacy to fix IE Issue

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -25,13 +25,13 @@ class CSVLink extends React.Component {
 /**
    * In IE11 this method will trigger the file download
    */
-  handleLegacy(evt, data, headers, separator, filename) {
+  handleLegacy(evt, data, headers, separator, filename, uFEFF) {
     // If this browser is IE 11, it does not support the `download` attribute
     if (window.navigator.msSaveOrOpenBlob) {
       // Stop the click propagation
       evt.preventDefault()
 
-      let blob = new Blob([toCSV(data, headers, separator)])
+      let blob = new Blob([uFEFF ? '\uFEFF' : '', toCSV(data, headers, separator)])
       window.navigator.msSaveBlob(blob, filename)
 
       return false
@@ -44,7 +44,7 @@ class CSVLink extends React.Component {
       <a download={filename} {...rest}
          ref={link => (this.link = link)}
          href={this.buildURI(data, uFEFF, headers, separator)}
-         onClick={evt => this.handleLegacy(evt, data, headers, separator, filename)}>
+         onClick={evt => this.handleLegacy(evt, data, headers, separator, filename, uFEFF)}>
         {children}
       </a>
     )


### PR DESCRIPTION
Added uFEFF to CSVLink's handleLegacy function, fixing an IE11 issue. See #60