### PR TITLE
Use CSVLink to allow filename for CSVDownload

### DIFF
--- a/src/components/Download.js
+++ b/src/components/Download.js
@@ -1,11 +1,5 @@
 import React from 'react';
-import {buildURI} from '../core';
-import {
-   defaultProps as commonDefaultProps,
-   propTypes as commonPropTypes} from '../metaProps';
-const defaultProps = {
-  target: '_blank'
-};
+import { CSVLink } from '../index'
 
 /**
  *
@@ -13,35 +7,22 @@ const defaultProps = {
  */
 class CSVDownload extends React.Component {
 
-  static defaultProps = Object.assign(
-    commonDefaultProps,
-    defaultProps
-  );
-
-  static propTypes = commonPropTypes;
-
   constructor(props) {
     super(props);
-    this.state={};
+    this.state= { hasTriggered: false };
+    this.handleRef = this.handleRef.bind(this);
   }
 
-  buildURI() {
-    return buildURI(...arguments);
+  handleRef(ref) {
+    if (ref) {
+      ref.link.click();
+      this.setState({ hasTriggered: true});
+    }
   }
 
-  componentDidMount(){
-    const {data, headers, separator, enclosingCharacter, uFEFF, target, specs, replace} = this.props;
-    this.state.page = window.open(
-        this.buildURI(data, uFEFF, headers, separator, enclosingCharacter), target, specs, replace
-    );
-  }
-
-  getWindow() {
-    return this.state.page;
-  }
-
-  render(){
-    return (null)
+  render() {
+    if (this.state.hasTriggered) return null;
+    return <CSVLink ref={this.handleRef} {...this.props} />;
   }
 }
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -15,22 +15,20 @@ class CSVLink extends React.Component {
 
   constructor(props) {
     super(props);
-    this.buildURI = this.buildURI.bind(this);
-    this.state = { href: '' };
+    this.getURI = this.getURI.bind(this);
   }
 
-  componentDidMount() {
-    const {data, headers, separator, uFEFF, enclosingCharacter} = this.props;
-    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter) });
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { data, headers, separator, uFEFF } = nextProps;
-    this.setState({ href: this.buildURI(data, uFEFF, headers, separator) });
-  }
-
-  buildURI() {
-    return buildURI(...arguments);
+  // Caches a single value of the built data URI.
+  getURI() {
+    const {data, headers, separator, uFEFF} = this.props;
+    if (this._data !== data || this._headers !== headers || this._separator !== separator || this._uFEFF == uFEFF) {
+      this._uri = buildURI(data, uFEFF, headers, separator);
+      this._data = data;
+      this._headers = headers;
+      this._separator = separator;
+      this._uFEFF = uFEFF;
+    }
+    return this._uri;
   }
 
   /**
@@ -101,7 +99,7 @@ class CSVLink extends React.Component {
         {...rest}
         ref={link => (this.link = link)}
         target="_self"
-        href={this.state.href}
+        href={this.getURI()}
         onClick={this.handleClick(data, headers, separator, filename, enclosingCharacter)}
       >
         {children}

--- a/test/ComponentsSpec.js
+++ b/test/ComponentsSpec.js
@@ -2,7 +2,8 @@ import jsdom from 'jsdom-global';
 import React from 'react';
 import {
  mount,
- shallow
+ shallow,
+ render
 } from 'enzyme';
 import sinon from 'sinon';
 import expect from 'expect';
@@ -69,10 +70,10 @@ describe('In browser environment', () => {
  
      it(`calls "buildURI" method on mounting`, () => {
        const dataURI = `data:text/csv;some,thing`
-       const buildURI = sinon.stub(CSVLink.prototype, 'buildURI').returns(dataURI);
+       const getURI = sinon.stub(CSVLink.prototype, 'getURI').returns(dataURI);
        const wrapper = mount( <CSVLink {...minProps} > Click here </CSVLink>);
-       expect(buildURI.calledOnce).toBeTruthy();
-       buildURI.restore();
+       expect(getURI.calledOnce).toBeTruthy();
+       getURI.restore();
      });
      it(`generates CSV download link and bind it to "href" of <a> element`, () => {
        const linkPrefix = `data:text/csv`
@@ -115,60 +116,25 @@ describe('In browser environment', () => {
        ],
        uFEFF: true
       };
-      manyProps= Object.assign(minProps, {
-       target: '_blank',
-       specs: 'fullscreen=yes&height=200&status=yes',
-       replace:'no'
-      });
      });
  
      it(`does not render anything by default`, () => {
        const wrapper = shallow( <CSVDownload {...minProps} />);
         expect(wrapper.props().children).toNotExist();
        });
-      it(`calls "buildURI" on mounting`, () => {
-        const dataURI = `data:text/csv;some,thing`
-        const buildURI = sinon.stub(CSVDownload.prototype, 'buildURI').returns(dataURI);
-        const wrapper = mount( <CSVDownload {...minProps} />);
-        expect(buildURI.calledOnce).toBeTruthy();
-        buildURI.restore();
+      it(`calls "handleRef" on mounting`, () => {
+        const handleRef = sinon.stub(CSVDownload.prototype, 'handleRef');
+        mount(<CSVDownload {...minProps} />);
+        expect(handleRef.calledOnce).toBeTruthy();
+        handleRef.restore();
       });
-      it(`redirects in different page on mounting`, () => {
-        const openCallback = sinon.stub(window,'open').returns({
-          focus: ()=> {}
-        });
-        const wrapper = mount( <CSVDownload {...manyProps} />);
-        expect(openCallback.calledWith(buildURI(manyProps.data, manyProps.uFEFF), manyProps.target, manyProps.specs, manyProps.replace)).toBeTruthy();
-        expect(openCallback.calledOnce).toBeTruthy();
-        openCallback.restore();
-       });
- 
-      it(`persists new opened window`, () => {
-        const openCallback = sinon.stub(window,'open').returns('newPage');
-        const wrapper = mount( <CSVDownload {...manyProps} />);
-        const actualNewWindow= wrapper.instance().getWindow();
-        expect(actualNewWindow).toEqual('newPage');
-        openCallback.restore();
- 
+      it(`includes no element in DOM on mounting`, () => {
+        const filename = 'persons.csv';
+        const handleRef = sinon.stub(CSVDownload.prototype, 'handleRef');
+        const wrapper = mount(<CSVDownload {...minProps} filename={filename} />)
+        expect(wrapper.find('a').get(0).getAttribute('download')).toEqual(filename);
+        handleRef.restore();
      });
   });
  
 })
-
-describe('In Node environment', () => {
-  it('does not call buildURI', () => {
-    const minProps = {
-      data: [
-       ['X', 'Y'],
-       ['1', '2'],
-       ['3', '4']
-      ]
-    };
-
-    const dataURI = `data:text/csv;some,thing`
-    const buildURI = sinon.stub(CSVLink.prototype, 'buildURI').returns(dataURI);
-    const wrapper = shallow( <CSVLink {...minProps} > Click here </CSVLink>);
-    expect(buildURI.notCalled).toBeTruthy();
-    buildURI.restore();
-  });
-});


### PR DESCRIPTION
This resolves the conflicts in #69 and uses release version 1.0.20

Additionally, `CSVLink` stops using unsafe componentWillReceiveProps

https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops

As suggested in React docs, since we are simply avoiding recomputing
when props change, we can use a simple memoization of the built data URI

This also fixes a bug with `CSVDownload` introduced in #69 where built data URI was built _after_ the CSVLink component mounts (via a `setState`). `CSVDownload` expects the `CSVLink` that it wraps to have the `href` set immediately. Since this built `href` data URI can be constructed synchronously from the `data` prop, we simply build it (or retrieve the memoized one) in the `render()` of the `CSVLink`