### PR TITLE
Use event.persist() if it's available to make preventDefault work

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -50,6 +50,9 @@ class CSVLink extends React.Component {
   }
 
   handleAsyncClick(event, ...args) {
+    if (event.persist) {
+      event.persist();
+    }
     const done = proceed => {
       if (proceed === false) {
         event.preventDefault();


### PR DESCRIPTION
`event.preventDefault()` doesn't do anything (in React 16, at least), unless event.persist() has been called non-asynchronously in the event handler.