### PR TITLE
Add ability to perform transform at end of joiner()

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -225,7 +225,7 @@
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>handleLegacy(event, data, headers, separator, filename)</span>
+            <span class='code strong strong truncate'>handleLegacy(event, data, headers, separator, filename, enclosingCharacter, transform)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -236,7 +236,7 @@
   <p>In IE11 this method will trigger the file download</p>
 
 
-  <div class='pre p1 fill-light mt0'>handleLegacy(event: any, data: any, headers: any, separator: any, filename: any)</div>
+  <div class='pre p1 fill-light mt0'>handleLegacy(event: any, data: any, headers: any, separator: any, filename: any, enclosingCharacter: any, transform: func)</div>
   
   
 

--- a/src/components/Download.js
+++ b/src/components/Download.js
@@ -30,9 +30,9 @@ class CSVDownload extends React.Component {
   }
 
   componentDidMount(){
-    const {data, headers, separator, enclosingCharacter, uFEFF, target, specs, replace} = this.props;
+    const {data, headers, separator, enclosingCharacter, uFEFF, target, specs, replace, transform} = this.props;
     this.state.page = window.open(
-        this.buildURI(data, uFEFF, headers, separator, enclosingCharacter), target, specs, replace
+        this.buildURI(data, uFEFF, headers, separator, enclosingCharacter), target, specs, replace, transform
     );
   }
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -20,13 +20,13 @@ class CSVLink extends React.Component {
   }
 
   componentDidMount() {
-    const {data, headers, separator, uFEFF, enclosingCharacter} = this.props;
-    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter) });
+    const {data, headers, separator, uFEFF, enclosingCharacter, transform} = this.props;
+    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter, transform) });
   }
 
   componentWillReceiveProps(nextProps) {
-    const { data, headers, separator, uFEFF } = nextProps;
-    this.setState({ href: this.buildURI(data, uFEFF, headers, separator) });
+    const { data, headers, separator, transform, uFEFF, enclosingCharacter } = nextProps;
+    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter, transform) });
   }
 
   buildURI() {
@@ -36,13 +36,13 @@ class CSVLink extends React.Component {
   /**
    * In IE11 this method will trigger the file download
    */
-  handleLegacy(event, data, headers, separator, filename, enclosingCharacter) {
+  handleLegacy(event, data, headers, separator, filename, enclosingCharacter, transform) {
     // If this browser is IE 11, it does not support the `download` attribute
     if (window.navigator.msSaveOrOpenBlob) {
       // Stop the click propagation
       event.preventDefault();
 
-      let blob = new Blob([toCSV(data, headers, separator, enclosingCharacter)]);
+      let blob = new Blob([toCSV(data, headers, separator, enclosingCharacter, transform)]);
       window.navigator.msSaveBlob(blob, filename);
 
       return false;
@@ -92,6 +92,7 @@ class CSVLink extends React.Component {
       onClick,
       asyncOnClick,
       enclosingCharacter,
+      transform,
       ...rest
     } = this.props;
 
@@ -102,7 +103,7 @@ class CSVLink extends React.Component {
         ref={link => (this.link = link)}
         target="_self"
         href={this.state.href}
-        onClick={this.handleClick(data, headers, separator, filename, enclosingCharacter)}
+        onClick={this.handleClick(data, headers, separator, filename, enclosingCharacter, transform)}
       >
         {children}
       </a>

--- a/src/core.js
+++ b/src/core.js
@@ -43,45 +43,45 @@ export const getHeaderValue = (property, obj) => {
         return o[p];
       }
     }, obj);
-  
+
   return (foundValue === undefined) ? '' : foundValue;
 }
 
 export const elementOrEmpty = (element) => element || element === 0 ? element : '';
 
-export const joiner = ((data, separator = ',', enclosingCharacter = '"') => {
+export const joiner = ((data, separator = ',', enclosingCharacter = '"', transform) => {
   return data
     .filter(e => e)
     .map(
       row => row
         .map((element) => elementOrEmpty(element))
-        .map(column => `${enclosingCharacter}${column}${enclosingCharacter}`)
+        .map(column => transform(`${enclosingCharacter}${column}${enclosingCharacter}`))
         .join(separator)
     )
     .join(`\n`);
 });
 
-export const arrays2csv = ((data, headers, separator, enclosingCharacter) =>
- joiner(headers ? [headers, ...data] : data, separator, enclosingCharacter)
+export const arrays2csv = ((data, headers, separator, enclosingCharacter, transform) =>
+ joiner(headers ? [headers, ...data] : data, separator, enclosingCharacter, transform)
 );
 
-export const jsons2csv = ((data, headers, separator, enclosingCharacter) =>
- joiner(jsons2arrays(data, headers), separator, enclosingCharacter)
+export const jsons2csv = ((data, headers, separator, enclosingCharacter, transform) =>
+ joiner(jsons2arrays(data, headers), separator, enclosingCharacter, transform)
 );
 
 export const string2csv = ((data, headers, separator, enclosingCharacter) =>
   (headers) ? `${headers.join(separator)}\n${data}`: data
 );
 
-export const toCSV = (data, headers, separator, enclosingCharacter) => {
- if (isJsons(data)) return jsons2csv(data, headers, separator, enclosingCharacter);
- if (isArrays(data)) return arrays2csv(data, headers, separator, enclosingCharacter);
+export const toCSV = (data, headers, separator, enclosingCharacter, transform) => {
+ if (isJsons(data)) return jsons2csv(data, headers, separator, enclosingCharacter, transform);
+ if (isArrays(data)) return arrays2csv(data, headers, separator, enclosingCharacter, transform);
  if (typeof data ==='string') return string2csv(data, headers, separator);
  throw new TypeError(`Data should be a "String", "Array of arrays" OR "Array of objects" `);
 };
 
-export const buildURI = ((data, uFEFF, headers, separator, enclosingCharacter) => {
-  const csv = toCSV(data, headers, separator, enclosingCharacter);
+export const buildURI = ((data, uFEFF, headers, separator, enclosingCharacter, transform = v => v) => {
+  const csv = toCSV(data, headers, separator, enclosingCharacter, transform);
   const type = isSafari() ? 'application/csv' : 'text/csv';
   const blob = new Blob([uFEFF ? '\uFEFF' : '', csv], {type});
   const dataURI = `data:${type};charset=utf-8,${uFEFF ? '\uFEFF' : ''}${csv}`;

--- a/src/metaProps.js
+++ b/src/metaProps.js
@@ -10,14 +10,16 @@ export const propTypes = {
   filename: string,
   uFEFF: bool,
   onClick: func,
-  asyncOnClick: bool
+  asyncOnClick: bool,
+  transform: func
 };
 
 export const defaultProps = {
   separator: ',',
   filename: 'generatedBy_react-csv.csv',
   uFEFF: true,
-  asyncOnClick: false
+  asyncOnClick: false,
+  transform: v => v,
 };
 
 export const PropsNotForwarded = [


### PR DESCRIPTION
This is useful if you want to perform some type of transformation at the very end, after the enclosing characters have been appended.

Example use case:

```jsx
<CSVLink
  {...props}
  transform={(v) => {
    if (v[1] === '=') {
      return `=${v.slice(0, 1)}${v.slice(2)}`;
    }
    return v;
  }}
/>
```