### PR TITLE
Component downloads previous state of props with redux #209

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -26,7 +26,7 @@ class CSVLink extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props !== prevProps) {
-      const { data, headers, separator, uFEFF } = prevProps;
+      const { data, headers, separator, uFEFF } = this.props;
       this.setState({ href: this.buildURI(data, uFEFF, headers, separator) });
     }
   }


### PR DESCRIPTION
https://github.com/react-csv/react-csv/issues/209

componentDidUpdate should use the current props and not the prevProps.
Without this change, it will always download the previous values after properties have changed.
This can also be reproduced in the sample-site by selecting different sample data sets and comparing the csv download with the displayed values.