### PR TITLE
Fix enclosingCharacter  lost on component update

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -26,8 +26,8 @@ class CSVLink extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props !== prevProps) {
-      const { data, headers, separator, uFEFF } = this.props;
-      this.setState({ href: this.buildURI(data, uFEFF, headers, separator) });
+      const { data, headers, separator, uFEFF, enclosingCharacter} = this.props;
+      this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter) });
     }
   }
 


### PR DESCRIPTION
Fix enclosingCharacter  lost on component update,

the setting enclosingCharacter was reset to undefined upon component update, this PR address this issue and fix it.