### PR TITLE
buildURI in render unless node environment

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -16,19 +16,6 @@ class CSVLink extends React.Component {
   constructor(props) {
     super(props);
     this.buildURI = this.buildURI.bind(this);
-    this.state = { href: '' };
-  }
-
-  componentDidMount() {
-    const {data, headers, separator, uFEFF, enclosingCharacter} = this.props;
-    this.setState({ href: this.buildURI(data, uFEFF, headers, separator, enclosingCharacter) });
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props !== prevProps) {
-      const { data, headers, separator, uFEFF } = this.props;
-      this.setState({ href: this.buildURI(data, uFEFF, headers, separator) });
-    }
   }
 
   buildURI() {
@@ -106,13 +93,16 @@ class CSVLink extends React.Component {
       ...rest
     } = this.props;
 
+    const isNodeEnvironment = typeof window === 'undefined';
+    const href = isNodeEnvironment ? '' : this.buildURI(data, uFEFF, headers, separator, enclosingCharacter)
+
     return (
       <a
         download={filename}
         {...rest}
         ref={link => (this.link = link)}
         target="_self"
-        href={this.state.href}
+        href={href}
         onClick={this.handleClick()}
       >
         {children}


### PR DESCRIPTION
Fixes #264 breaking change in v2 related to deprecating `componentWillReceiveProps` in favor of `componentDidUpdate`. These lifecycle methods have slight timing differences that can cause breaking changes in relation to v1 when building csv files on the fly.

To avoid any timing problems related to react lifecycle methods, better to calculate the `href` inside render, rather than rely on updating internal state.

This also fixes issue #241 