### PR TITLE
return result of evaluation from elementOrEmpty

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -47,9 +47,8 @@ export const getHeaderValue = (property, obj) => {
   return (foundValue === undefined) ? ((property in obj) ? obj[property] : '') : foundValue;
 }
 
-export const elementOrEmpty = (element) => {
+export const elementOrEmpty = (element) => 
   (typeof element === 'undefined' || element === null) ? '' : element;
-};
 
 export const joiner = ((data, separator = ',', enclosingCharacter = '"') => {
   return data


### PR DESCRIPTION
This PR is an attempt to resolve [issue 293](https://github.com/react-csv/react-csv/issues/293)

Previously the elementOrEmpty function did not return the result of it's evaluation.

Code in PR returns the result of the evaluation.