### PR TITLE
test: Add unit test for elementOrEmpty() which was returning undefined

### DIFF
--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -219,15 +219,6 @@ describe('In browser environment', () => {
   });
 
   describe(`core::joiner`, () => {
-    it(`returns the csv string of the data`, () => {
-      const expected = '"1","two","3","true"\n"4","","six","false"';
-      const actual = joiner([
-        [ 1, 'two', 3, true],
-        null,
-        [ 4.0, undefined, 'six', false]
-      ]);
-      expect(actual).toEqual(expected);
-    });
   });
 
   describe(`core::arrays2csv`, () => {
@@ -378,6 +369,15 @@ describe('In browser environment', () => {
     const data = [null, undefined, [1, 2, 3, 5], ["hello hello"]];
     it('does not throw upon receiving empty (null / undefined) indices in the data array', () => {
       expect(joiner).toNotThrow(data);
+    });
+    it(`filters null rows and replaces null / undefined values by an empty string`, () => {
+      const expected = '"1","two","3","true"\n"4","","six","false"';
+      const actual = joiner([
+        [ 1, 'two', 3, true],
+        null,
+        [ 4.0, undefined, 'six', false]
+      ]);
+      expect(actual).toEqual(expected);
     });
     it('does return the valid data contained between null and undefined values', () => {
       expect(joiner(data)).toMatch('"1","2","3","5"\n"hello hello"');

--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -10,7 +10,8 @@ import {
   string2csv,
   toCSV,
   buildURI,
-  joiner
+  joiner,
+  elementOrEmpty,
 } from '../src/core';
 
 describe('In browser environment', () => {
@@ -197,6 +198,34 @@ describe('In browser environment', () => {
         ['', '', '', '', 'john', ''],
         ['', '', '', '', '', '20']
       ];
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe(`core::elementOrEmpty`, () => {
+    it(`returns the value of the element`, () => {
+      const expected = "any string ...";
+      const actual = elementOrEmpty(expected);
+      expect(actual).toEqual(expected);
+    });
+
+    it(`returns an empty string when the element is null or undefined`, () => {
+      const emptyString = '';
+      const wasNull = elementOrEmpty(null);
+      const wasUndefined = elementOrEmpty(undefined);
+      expect(wasNull).toEqual(emptyString);
+      expect(wasUndefined).toEqual(emptyString);
+    });
+  });
+
+  describe(`core::joiner`, () => {
+    it(`returns the csv string of the data`, () => {
+      const expected = '"1","two","3","true"\n"4","","six","false"';
+      const actual = joiner([
+        [ 1, 'two', 3, true],
+        null,
+        [ 4.0, undefined, 'six', false]
+      ]);
       expect(actual).toEqual(expected);
     });
   });


### PR DESCRIPTION
## Scope

While I was testing CSVLink, all the CSV values seemed to be undefined. It turned out that the elementOrEmpty() wasn't returning anything. Once I rebased, the issue was gone, So I just added a unit test for it.