### PR TITLE
Fix/Introduce FileReader to properly base64 encode the data URL

### DIFF
--- a/sample-site/src/app.jsx
+++ b/sample-site/src/app.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
-import {CSVLink, CSVDownload} from 'react-csv';
+import { CSVLink } from 'react-csv';
 import Table from './Table.jsx';
 
 const csvHeaders1 = [
-"Company","جهة الإتصال ","王玉普"
+  "Company","جهة الإتصال ","王玉普", "symbol"
 ]
 const csvData1 = [
-  ['Alfreds Futterkiste'	,'Maria Anders',	'Germany'] ,
-  ['Rathath IT', 'Abdennour TM' , 'تونس'] ,
-  ['Sinopec', '王玉普' , '中国'],
-  ['Auto1', 'Petter' , 'Germany'] ,
-  ['Estifeda', 'Yousri K' , 'تونس'] ,
-  ['Nine 10ᵗʰ', 'Amjed Idris' , 'المملكة العربية السعودية '] ,
-  ['Tamkeen', 'Mohamed Alshibi' , 'المملكة العربية السعودية'] ,
-  ['Packet Publishing', 'David Become' , 'UK'] ,
-  ['Software hourse', 'Soro' , 'Poland']
+  ['Alfreds Futterkiste'	,'Maria Anders',	'Germany', "€"] ,
+  ['Rathath IT', 'Abdennour TM' , 'تونس', 'TND'] ,
+  ['Sinopec', '王玉普' , '中国', '£'],
+  ['Auto1', 'Petter' , 'Germany', '$'] ,
+  ['Estifeda', 'Yousri K' , 'تونس', '#'] ,
+  ['Nine 10ᵗʰ', 'Amjed Idris' , 'المملكة العربية السعودية ', '&'] ,
+  ['Tamkeen', 'Mohamed Alshibi' , 'المملكة العربية السعودية', '*'] ,
+  ['Packet Publishing', 'David Become' , 'UK', '?'] ,
+  ['Software hourse', 'Soro' , 'Poland', '|']
 ];
 
 const csvHeaders2 = [

--- a/src/components/Download.js
+++ b/src/components/Download.js
@@ -29,11 +29,11 @@ class CSVDownload extends React.Component {
     return buildURI(...arguments);
   }
 
-  componentDidMount(){
+  componentWillMount(){
     const {data, headers, separator, enclosingCharacter, uFEFF, target, specs, replace} = this.props;
-    this.state.page = window.open(
-        this.buildURI(data, uFEFF, headers, separator, enclosingCharacter), target, specs, replace
-    );
+    this.buildURI(data, uFEFF, headers, separator, enclosingCharacter).then((dataUrl) => {
+      this.state.page = window.open(dataUrl, target, specs, replace);
+    })
   }
 
   getWindow() {

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { buildURI, toCSV } from '../core';
+import { buildURI, toCSV, isNodeEnvironment } from '../core';
 import {
   defaultProps as commonDefaultProps,
   propTypes as commonPropTypes
@@ -16,6 +16,9 @@ class CSVLink extends React.Component {
   constructor(props) {
     super(props);
     this.buildURI = this.buildURI.bind(this);
+    this.state = {
+      href: '#',
+    }
   }
 
   buildURI() {
@@ -81,6 +84,30 @@ class CSVLink extends React.Component {
     };
   }
 
+  componentWillMount() {
+    this.generateHref(this.props);
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.generateHref(newProps);
+  }
+
+  generateHref(props) {
+    const {
+      data,
+      headers,
+      separator,
+      uFEFF,
+      enclosingCharacter,
+    } = props;
+    this.buildURI(data, uFEFF, headers, separator, enclosingCharacter).then((dataUrl) => {
+      this.setState({
+        ...this.state,
+        href: dataUrl
+      })
+    });
+  }
+
   render() {
     const {
       data,
@@ -94,9 +121,7 @@ class CSVLink extends React.Component {
       enclosingCharacter,
       ...rest
     } = this.props;
-
-    const isNodeEnvironment = typeof window === 'undefined';
-    const href = isNodeEnvironment ? '' : this.buildURI(data, uFEFF, headers, separator, enclosingCharacter)
+    const { href } = this.state;
 
     return (
       <a

--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -315,34 +315,41 @@ describe('In browser environment', () => {
 
   describe(`core::buildURI`, () => {
     let fixtures;
+    let prefixCsvURI;
+    let separator;
     beforeEach(() => {
+      separator = ',';
+      prefixCsvURI = `data:text/csv;base64,`;
       fixtures = { string: 'Xy', arrays: [['a', 'b'], ['c', 'd']], jsons: [{}, {}] };
+      global.FileReader = function () {
+        this.result = `${prefixCsvURI}${joiner(fixtures.arrays, separator)}`;
+        this.onloadend = null;
+        this.readAsDataURL = () => this.onloadend()
+      }
     });
 
-    it(`generates URI to download data in CSV format`, () => {
-      const prefixCsvURI = `data:text/csv;`;
-      expect(buildURI(fixtures.jsons, false).startsWith(prefixCsvURI)).toBeTruthy();
-      expect(buildURI(fixtures.arrays).startsWith(prefixCsvURI)).toBeTruthy();
-      expect(buildURI(fixtures.string).startsWith(prefixCsvURI)).toBeTruthy();
-
+    it(`generates URI to download data in CSV format`, async () => {
+      const jsonFixtureDataURL = await buildURI(fixtures.jsons, false);
+      expect(jsonFixtureDataURL.startsWith(prefixCsvURI)).toBeTruthy();
+      const arrayFixtureDataURL = await buildURI(fixtures.arrays);
+      expect(arrayFixtureDataURL.startsWith(prefixCsvURI)).toBeTruthy();
+      const stringFixtureDataURL = await buildURI(fixtures.string);
+      expect(stringFixtureDataURL.startsWith(prefixCsvURI)).toBeTruthy();
     });
 
-    it(`generates CSV string according to "separator"`, () => {
-      const prefixCsvURI = `data:text/csv;charset=utf-8,\uFEFF,`;
+    it(`generates CSV string according to "separator"`, async () => {
       const expectedSepartorCount = fixtures.arrays.map(row => row.length - 1).reduce((total, next) => total + next, 0);
-      let separator = ';';
-      let fullURI = buildURI(fixtures.arrays, true, null, separator);
-
+      separator = ';';
+      let fullURI = await buildURI(fixtures.arrays, true, null, separator);
       expect(
         fullURI.slice(prefixCsvURI.length).match(/;/g).length
       ).toEqual(expectedSepartorCount);
 
       separator = ':'; // any separator
-      fullURI = buildURI(fixtures.arrays, true, null, separator);
+      fullURI = await buildURI(fixtures.arrays, true, null, separator);
       expect(
         fullURI.slice(prefixCsvURI.length).match(/:/g).length
       ).toEqual(expectedSepartorCount);
-
     });
   });
   describe('core::joiner', () => {


### PR DESCRIPTION
## Motivation
The PR https://github.com/react-csv/react-csv/pull/58 is adressing already the base64 encoding issue but : 
- btoa() is deprecated
- It's better to use FileReader.readAsDataURL() method so that we delegate the data URL generation to the browser implementation rather then self building the URL and encoding it.

## Whas has been changed ?
- buildURI() does not return a promise.
- Updated both Link and Download components accodingly so that the "href" is re-generated upon props update.
- Adapted unit tests accordingly.