### PR TITLE
escape quotation mark for data in json & array format

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -57,7 +57,7 @@ export const joiner = ((data, separator = ',', enclosingCharacter = '"') => {
     .map(
       row => row
         .map((element) => elementOrEmpty(element))
-        .map(column => `${enclosingCharacter}${column}${enclosingCharacter}`)
+        .map(column => `${enclosingCharacter}${column.replace(/"/g, '""')}${enclosingCharacter}`)
         .join(separator)
     )
     .join(`\n`);


### PR DESCRIPTION
version 2.2.1 add the ability to escape quotation mark for data in string format, but not json & array format
#287 