### PR TITLE
If `data` is a function, do not throw and error 

### DIFF
--- a/src/components/Link.jsx
+++ b/src/components/Link.jsx
@@ -96,7 +96,8 @@ class CSVLink extends React.Component {
     } = this.props;
 
     const isNodeEnvironment = typeof window === 'undefined';
-    const href = isNodeEnvironment ? '' : this.buildURI(data, uFEFF, headers, separator, enclosingCharacter)
+    const csvData = typeof data === 'function' ? data() : data;
+    const href = isNodeEnvironment ? '' : this.buildURI(csvData, uFEFF, headers, separator, enclosingCharacter)
 
     return (
       <a


### PR DESCRIPTION
`toCSV` used inside the `buildURI` method throws a TypeError when passing `data` without this check.

 `throw new TypeError(`Data should be a "String", "Array of arrays" OR "Array of objects" `);`